### PR TITLE
refactor: use txn_info.signature for plugin configuration

### DIFF
--- a/contracts/account/IPluginAccount.cairo
+++ b/contracts/account/IPluginAccount.cairo
@@ -9,13 +9,13 @@ namespace IPluginAccount {
     // Plugin
     /////////////////////
 
-    func addPlugin(plugin: felt) {
+    func addPlugin(plugin: felt, plugin_calldata_len: felt, plugin_calldata: felt*) {
     }
 
     func removePlugin(plugin: felt) {
     }
 
-    func setDefaultPlugin(plugin: felt, plugin_calldata_len: felt, plugin_calldata: felt*) {
+    func setDefaultPlugin(plugin: felt) {
     }
 
     func isPlugin(plugin: felt) -> (success: felt) {

--- a/contracts/plugins/IPlugin.cairo
+++ b/contracts/plugins/IPlugin.cairo
@@ -9,8 +9,6 @@ namespace IPlugin {
     }
 
     func validate(
-        plugin_data_len: felt,
-        plugin_data: felt*,
         call_array_len: felt,
         call_array: CallArray*,
         calldata_len: felt,

--- a/contracts/plugins/signer/StarkSigner.cairo
+++ b/contracts/plugins/signer/StarkSigner.cairo
@@ -72,8 +72,6 @@ func supportsInterface{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_che
 func validate{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr, ecdsa_ptr: SignatureBuiltin*
 }(
-    plugin_data_len: felt,
-    plugin_data: felt*,
     call_array_len: felt,
     call_array: CallArray*,
     calldata_len: felt,
@@ -97,8 +95,8 @@ func is_valid_signature{
 ) -> (is_valid: felt) {
     let (public_key) = StarkSigner_public_key.read();
 
-    let sig_r = signature[0];
-    let sig_s = signature[1];
+    let sig_r = signature[2];
+    let sig_s = signature[3];
 
     verify_ecdsa_signature(
         message=hash,

--- a/contracts/plugins/signer/StarkSigner.cairo
+++ b/contracts/plugins/signer/StarkSigner.cairo
@@ -95,8 +95,8 @@ func is_valid_signature{
 ) -> (is_valid: felt) {
     let (public_key) = StarkSigner_public_key.read();
 
-    let sig_r = signature[2];
-    let sig_s = signature[3];
+    let sig_r = signature[1];
+    let sig_s = signature[2];
 
     verify_ecdsa_signature(
         message=hash,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-cairo-lang>=0.9.1
-cairo-nile>=0.8.0
+cairo-lang>=0.10.0
+cairo-nile>=0.9.0
 pytest>=7.1.2
 pytest-asyncio>=0.19.0

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -57,7 +57,7 @@ class StarkSigner():
             additional_data=[nonce],
         )
 
-        signatures = list(self.sign(transaction_hash))
+        signatures = [0] + list(self.sign(transaction_hash))
 
         external_tx = InvokeFunction(
             contract_address=account.contract_address,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -38,10 +38,8 @@ class StarkSigner():
         return sign(msg_hash=message_hash, priv_key=self.private_key)
 
     async def send_transaction(self, account, calls, nonce: Optional[int] = None, max_fee: Optional[int] = 0) -> TransactionExecutionInfo :
-
-        calls_with_selector = [(call[0], get_selector_from_name(call[1]), call[2]) for call in calls]
         call_array, calldata = from_call_to_call_array(calls)
-        
+
         raw_invocation = account.__execute__(call_array, calldata)
         state = raw_invocation.state
 


### PR DESCRIPTION
Refactors the base plugin account to use `txn_info` for plugin selection. The big upside is that it enables plugins to validate signatures, which opens up additional use cases, e.g. state channels using session keys.

Additionally, it modifies the implementation:

1) Removes the `_default_plugins` storage var and instead uses the `0` slot in `_plugins` to store it.
2) Removes the `USE_PLUGIN_SELECTOR` and uses the first entry in the signature, for default plugin it should be 0, otherwise attempt to use the specified plugin.
3) Modifies the interface to support (optionally) initializing a plugin on add.
4) Modifies the interface to only support setting an previously added plugin as default.

All in, it seems like a pretty nice simplification of the logic while enabling additional transaction validation flows.

Resolves #2 #6 