### PR TITLE
fallback to default plugin when no plugin is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ For every transaction the caller can instruct the account to validate the multi-
 
 We note that the plugin must be called with a `library_call` to comply to the constraints of the `__validate__` method, which prevents accessing the storage of other contracts. I.e. the logic of the plugin is executed in the context of the account and the state of the plugin, if any, must be stored in the account.
 
-To instruct the account to use a specific plugin we leverage the transaction signature data. By convention, the first item in the signature data specifies either `0` (the default plugin) or the class hash of the plugin which should be used for validation. Any additional context necessary to validate the transaction, such as the signature itself, should be appended to the signature data.
+To instruct the account to use a specific plugin we leverage the transaction signature data. By convention, the first item in the signature data specifies the class hash of the plugin which should be used for validation. If no valid plugin is specified the default plugin is used. Any additional context necessary to validate the transaction, such as the signature itself, should be appended to the signature data.
 
-So to validate a call using the default plugin, the signature data should look like: `[0, ...]` and to validate it against a specific plugin, the signature data should look like `[pluginClassHash, ...]`
+So to validate a call using a specific plugin, the signature data should look like `[pluginClassHash, ...]`
 
 Similarly, the `isValidSignature` will validate a signature using the provided plugin in the passed signature data.
 

--- a/contracts/account/PluginAccount.cairo
+++ b/contracts/account/PluginAccount.cairo
@@ -104,7 +104,7 @@ func __validate_deploy__{
 @raw_output
 func __execute__{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ecdsa_ptr: SignatureBuiltin*, range_check_ptr
-}(
+} (
     call_array_len: felt, call_array: CallArray*, calldata_len: felt, calldata: felt*
 ) -> (retdata_size: felt, retdata: felt*) {
     alloc_locals;
@@ -331,17 +331,14 @@ func use_plugin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}
 
     let (tx_info) = get_tx_info();
     let plugin_id = tx_info.signature[0];
-    let (value) = _plugins.read(plugin_id);
+    let (is_plugin) = _plugins.read(plugin_id);
 
-    if (plugin_id == 0) {
-        return (plugin_id=value);
+    if (is_plugin == TRUE) {
+        return (plugin_id=plugin_id);
+    } else {
+        let (default_plugin) = _plugins.read(0);
+        return (plugin_id=default_plugin);
     }
-
-    with_attr error_message("PluginAccount: unknown plugin") {
-        assert_not_zero(value);
-    }
-
-    return (plugin_id=plugin_id);
 }
 
 func validate_with_plugin{


### PR DESCRIPTION
Use the default plugin when no plugin is specified, i.e. the first entry of the `signature` array is the `r` value of a signature.