### PR TITLE
feat: chainable middleware

### DIFF
--- a/contracts/plugins/IPlugin.cairo
+++ b/contracts/plugins/IPlugin.cairo
@@ -1,6 +1,6 @@
 %lang starknet
 
-from contracts.account.library import CallArray
+from contracts.account.library import Call
 
 @contract_interface
 namespace IPlugin {
@@ -9,10 +9,17 @@ namespace IPlugin {
     }
 
     func validate(
-        call_array_len: felt,
-        call_array: CallArray*,
-        calldata_len: felt,
-        calldata: felt*,
+        hash: felt, 
+        sig_len: felt,
+        sig: felt*,
+        calls_len: felt,
+        calls: Call*
     ) {
+    }
+
+    func execute(
+        calls_len: felt,
+        calls: Call*,
+    ) -> (calls_len: felt, calls: Call*, response_len: felt, response: felt*) {
     }
 }


### PR DESCRIPTION
A rough poc of supporting chainable plugins for both `validate` and `execute`.

It modifies the expected signature payload to include a second argument which describes the particular plugins signature length.

```
plugin0_selector, plugin0_signature_length, plugin0_signature0, plugin0_signature1, ..., pluginN_selector, pluginN_signature_length, pluginN_signature0, pluginN_signature1]
```

Plugins also behave similar behavior to http middleware where they can be chained and are able to mutate intermediate values, i.e. a plugin can operate on a provided `Call` and remove it from the execution payload for subsequent plugins.