### PR TITLE
Validate signature length

### DIFF
--- a/contracts/account/IPluginAccount.cairo
+++ b/contracts/account/IPluginAccount.cairo
@@ -18,10 +18,6 @@ namespace IPluginAccount {
     func isPlugin(plugin: felt) -> (success: felt) {
     }
 
-    ///////////// TODO, improve this
-    ///////////// Despite the name this method can actually execute on the plugins
-    func readOnPlugin(plugin: felt, selector: felt, calldata_len: felt, calldata: felt*) {
-    }
 
     func executeOnPlugin(
         plugin: felt, selector: felt, calldata_len: felt, calldata: felt*

--- a/contracts/account/IPluginAccount.cairo
+++ b/contracts/account/IPluginAccount.cairo
@@ -18,6 +18,8 @@ namespace IPluginAccount {
     func isPlugin(plugin: felt) -> (success: felt) {
     }
 
+    ///////////// TODO, improve this
+    ///////////// Despite the name this method can actually execute on the plugins
     func readOnPlugin(plugin: felt, selector: felt, calldata_len: felt, calldata: felt*) {
     }
 

--- a/contracts/account/PluginAccount.cairo
+++ b/contracts/account/PluginAccount.cairo
@@ -212,8 +212,6 @@ func executeOnPlugin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check
     plugin: felt, selector: felt, calldata_len: felt, calldata: felt*
 ) -> (retdata_len: felt, retdata: felt*) {
 
-    // only called via execute
-    assert_only_self();
     // only valid plugin
     let (is_plugin) = _plugins.read(plugin);
     assert_not_zero(is_plugin);
@@ -273,22 +271,6 @@ func isPlugin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(p
     return (success=res);
 }
 
-@view
-func readOnPlugin{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    plugin: felt, selector: felt, calldata_len: felt, calldata: felt*
-) -> (retdata_len: felt, retdata: felt*) {
-    let (is_plugin) = _plugins.read(plugin);
-    with_attr error_message("PluginAccount: unknown plugin") {
-        assert_not_zero(is_plugin);
-    }
-    let (retdata_len: felt, retdata: felt*) = library_call(
-        class_hash=plugin,
-        function_selector=selector,
-        calldata_size=calldata_len,
-        calldata=calldata,
-    );
-    return (retdata_len=retdata_len, retdata=retdata);
-}
 
 @view
 func getName() -> (name: felt) {

--- a/contracts/plugins/SessionKey.cairo
+++ b/contracts/plugins/SessionKey.cairo
@@ -104,6 +104,14 @@ func validate{
         let session_token = tx_info.signature + session_token_offset + 1;
     }
 
+    with_attr error_message("SessionKey: invalid proof len") {
+         assert proofs_len = call_array_len * proof_len;
+    }
+
+    with_attr error_message("SessionKey: invalid signature length") {
+        assert tx_info.signature_len = session_token_offset + 1 + session_token_len;
+    }
+
     with_attr error_message("SessionKey: session expired") {
         let (now) = get_block_timestamp();
         assert_nn(session_expires - now);

--- a/contracts/plugins/SessionKey.cairo
+++ b/contracts/plugins/SessionKey.cairo
@@ -151,6 +151,8 @@ func validate{
 func revokeSessionKey{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
     session_key: felt
 ) {
+    assert_only_self();
+
     SessionKey_revoked_keys.write(session_key, 1);
     session_key_revoked.emit(session_key);
     return ();
@@ -280,4 +282,14 @@ func calc_merkle_root{pedersen_ptr: HashBuiltin*, range_check_ptr}(
 
     let (res) = calc_merkle_root(node, proof_len - 1, proof + 1);
     return (res,);
+}
+
+
+func assert_only_self{syscall_ptr: felt*}() -> () {
+    let (self) = get_contract_address();
+    let (caller_address) = get_caller_address();
+    with_attr error_message("SessionKey: only self") {
+        assert self = caller_address;
+    }
+    return ();
 }

--- a/contracts/plugins/signer/StarkSigner.cairo
+++ b/contracts/plugins/signer/StarkSigner.cairo
@@ -87,6 +87,11 @@ func is_valid_signature{
     signature_len: felt,
     signature: felt*
 ) -> (is_valid: felt) {
+
+    with_attr error_message("StarkSigner: invalid signature length") {
+        assert signature_len = 3;
+    }
+    
     let (public_key) = StarkSigner_public_key.read();
 
     let sig_r = signature[1];

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -66,19 +66,19 @@ async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_
     stark_plugin_signer = StarkPluginSigner(
         stark_key=signer_key,
         account=account,
-        plugin_address=sts_plugin_decl.class_hash
+        plugin_class_hash=sts_plugin_decl.class_hash
     )
 
     stark_plugin_signer_2 = StarkPluginSigner(
         stark_key=signer_key_2,
         account=account_2,
-        plugin_address=sts_plugin_decl.class_hash
+        plugin_class_hash=sts_plugin_decl.class_hash
     )
 
     session_plugin_signer = SessionPluginSigner(
         stark_key=session_key,
         account=account,
-        plugin_address=session_key_decl.class_hash
+        plugin_class_hash=session_key_decl.class_hash
     )
     dapp = build_contract(dapp_setup, state=clean_state)
 
@@ -88,21 +88,21 @@ async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_
 @pytest.mark.asyncio
 async def test_addPlugin(network):
     account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
-    plugin_address = session_plugin_signer.plugin_address
-    assert (await account.isPlugin(plugin_address).call()).result.success == 0
-    await stark_plugin_signer.add_plugin(plugin_address)
-    assert (await account.isPlugin(plugin_address).call()).result.success == 1
+    plugin_class_hash = session_plugin_signer.plugin_class_hash
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
+    await stark_plugin_signer.add_plugin(plugin_class_hash)
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 1
 
 
 @pytest.mark.asyncio
 async def test_removePlugin(network):
     account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
-    plugin_address = session_plugin_signer.plugin_address
-    assert (await account.isPlugin(plugin_address).call()).result.success == 0
-    await stark_plugin_signer.add_plugin(plugin_address)
-    assert (await account.isPlugin(plugin_address).call()).result.success == 1
-    await stark_plugin_signer.remove_plugin(plugin_address)
-    assert (await account.isPlugin(plugin_address).call()).result.success == 0
+    plugin_class_hash = session_plugin_signer.plugin_class_hash
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
+    await stark_plugin_signer.add_plugin(plugin_class_hash)
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 1
+    await stark_plugin_signer.remove_plugin(plugin_class_hash)
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
 
 
 @pytest.mark.asyncio
@@ -140,7 +140,7 @@ async def test_executeOnPlugin(network):
 
     set_public_key_arguments = [signer_key_2.public_key]
     exec_arguments = [
-        stark_plugin_signer.plugin_address,
+        stark_plugin_signer.plugin_class_hash,
         get_selector_from_name("setPublicKey"),
         len(set_public_key_arguments),
         *set_public_key_arguments

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,14 +2,16 @@ import pytest
 import asyncio
 import logging
 from starkware.starknet.testing.starknet import Starknet
-from utils.utils import compile, build_contract, assert_event_emitted, StarkKeyPair, str_to_felt, ERC165_INTERFACE_ID, ERC165_ACCOUNT_INTERFACE_ID
+from utils.utils import compile, build_contract, assert_event_emitted, StarkKeyPair, assert_revert
 from utils.plugin_signer import StarkPluginSigner
 from utils.session_keys_utils import SessionPluginSigner
+from starkware.starknet.compiler.compile import get_selector_from_name
 
 
 LOGGER = logging.getLogger(__name__)
 
 signer_key = StarkKeyPair(123456789987654321)
+signer_key_2 = StarkKeyPair(123456789987654322)
 session_key = StarkKeyPair(666666666666666666)
 
 VERSION = '0.0.1'
@@ -28,12 +30,14 @@ async def starknet():
 async def account_setup(starknet: Starknet):
     account_cls = compile('contracts/account/PluginAccount.cairo')
     sts_plugin_cls = compile("contracts/plugins/signer/StarkSigner.cairo")
-    account_decl = await starknet.declare(contract_class=account_cls)
     sts_plugin_decl = await starknet.declare(contract_class=sts_plugin_cls)
 
     account = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
     await account.initialize(sts_plugin_decl.class_hash, [signer_key.public_key]).execute()
-    return account, account_cls, sts_plugin_decl
+
+    account2 = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
+    await account2.initialize(sts_plugin_decl.class_hash, [signer_key_2.public_key]).execute()
+    return account, account2, account_cls, sts_plugin_decl
 
 
 @pytest.fixture(scope='module')
@@ -52,15 +56,22 @@ async def dapp_setup(starknet: Starknet):
 
 @pytest.fixture
 async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_setup):
-    account, account_cls, sts_plugin_decl = account_setup
+    account, account_2, account_cls, sts_plugin_decl = account_setup
     session_key_decl = session_plugin_setup
 
     clean_state = starknet.state.copy()
     account = build_contract(account, state=clean_state)
+    account_2 = build_contract(account_2, state=clean_state)
 
     stark_plugin_signer = StarkPluginSigner(
         stark_key=signer_key,
         account=account,
+        plugin_address=sts_plugin_decl.class_hash
+    )
+
+    stark_plugin_signer_2 = StarkPluginSigner(
+        stark_key=signer_key_2,
+        account=account_2,
         plugin_address=sts_plugin_decl.class_hash
     )
 
@@ -71,12 +82,12 @@ async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_
     )
     dapp = build_contract(dapp_setup, state=clean_state)
 
-    return account, stark_plugin_signer, session_plugin_signer, dapp
+    return account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp
 
 
 @pytest.mark.asyncio
 async def test_addPlugin(network):
-    account, stark_plugin_signer, session_plugin_signer, dapp = network
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     plugin_address = session_plugin_signer.plugin_address
     assert (await account.isPlugin(plugin_address).call()).result.success == 0
     await stark_plugin_signer.add_plugin(plugin_address)
@@ -85,7 +96,7 @@ async def test_addPlugin(network):
 
 @pytest.mark.asyncio
 async def test_removePlugin(network):
-    account, stark_plugin_signer, session_plugin_signer, dapp = network
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     plugin_address = session_plugin_signer.plugin_address
     assert (await account.isPlugin(plugin_address).call()).result.success == 0
     await stark_plugin_signer.add_plugin(plugin_address)
@@ -96,7 +107,7 @@ async def test_removePlugin(network):
 
 @pytest.mark.asyncio
 async def test_supportsInterface(network):
-    account, stark_plugin_signer, session_plugin_signer, dapp = network
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     assert (await account.supportsInterface(ERC165_INTERFACE_ID).call()).result.success == 1
     assert (await account.supportsInterface(ERC165_ACCOUNT_INTERFACE_ID).call()).result.success == 1
     assert (await account.supportsInterface(0x123).call()).result.success == 0
@@ -105,16 +116,44 @@ async def test_supportsInterface(network):
 
 @pytest.mark.asyncio
 async def test_dapp(network):
-    account, stark_plugin_signer, session_plugin_signer, dapp = network
+    account, stark_plugin_signer, stark_plugin_signer, session_plugin_signer, dapp = network
     assert (await dapp.get_balance().call()).result.res == 0
     tx_exec_info = await stark_plugin_signer.send_transaction(
         calls=[(dapp.contract_address, 'set_balance', [47])],
     )
     assert_event_emitted(
         tx_exec_info,
-        from_address=account.contract_address,
+        from_address=stark_plugin_signer.account.contract_address,
         name='transaction_executed',
         data=[]
     )
     assert (await dapp.get_balance().call()).result.res == 47
 
+
+@pytest.mark.asyncio
+async def test_executeOnPlugin(network):
+    # Account 2 tries to change the signer key on Account 1, via executeOnPlugin and via readOnPlugin
+
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
+    read_execution_info = await stark_plugin_signer.read_on_plugin("getPublicKey")
+    assert read_execution_info.result[0] == [signer_key.public_key]
+
+    set_public_key_arguments = [signer_key_2.public_key]
+    exec_arguments = [
+        stark_plugin_signer.plugin_address,
+        get_selector_from_name("setPublicKey"),
+        len(set_public_key_arguments),
+        *set_public_key_arguments
+    ]
+    await assert_revert(
+        stark_plugin_signer_2.send_transaction(calls=[(stark_plugin_signer.account.contract_address, 'executeOnPlugin', exec_arguments)]),
+        reverted_with="PluginAccount: only self"
+    )
+
+    await assert_revert(
+        stark_plugin_signer_2.send_transaction(
+            calls=[(stark_plugin_signer.account.contract_address, 'readOnPlugin', exec_arguments)]),
+        reverted_with="StarkSigner: only self"
+    )
+    read_execution_info = await stark_plugin_signer.read_on_plugin("getPublicKey")
+    assert read_execution_info.result[0] == [signer_key.public_key]

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -2,7 +2,7 @@ import pytest
 import asyncio
 import logging
 from starkware.starknet.testing.starknet import Starknet
-from utils.utils import compile, build_contract, assert_event_emitted, StarkKeyPair, assert_revert
+from utils.utils import compile, build_contract, StarkKeyPair, ERC165_INTERFACE_ID, ERC165_ACCOUNT_INTERFACE_ID, assert_event_emitted, assert_revert, str_to_felt
 from utils.plugin_signer import StarkPluginSigner
 from utils.session_keys_utils import SessionPluginSigner
 from starkware.starknet.compiler.compile import get_selector_from_name
@@ -147,13 +147,8 @@ async def test_executeOnPlugin(network):
     ]
     await assert_revert(
         stark_plugin_signer_2.send_transaction(calls=[(stark_plugin_signer.account.contract_address, 'executeOnPlugin', exec_arguments)]),
-        reverted_with="PluginAccount: only self"
-    )
-
-    await assert_revert(
-        stark_plugin_signer_2.send_transaction(
-            calls=[(stark_plugin_signer.account.contract_address, 'readOnPlugin', exec_arguments)]),
         reverted_with="StarkSigner: only self"
     )
+
     read_execution_info = await stark_plugin_signer.read_on_plugin("getPublicKey")
     assert read_execution_info.result[0] == [signer_key.public_key]

--- a/tests/test_session_key.py
+++ b/tests/test_session_key.py
@@ -305,12 +305,5 @@ async def test_executeOnPlugin(starknet: Starknet, contracts):
         stark_plugin_signer_2.send_transaction(
             [(stark_plugin_signer.account.contract_address, 'executeOnPlugin', exec_arguments)]
         ),
-        reverted_with="PluginAccount: only self"
-    )
-
-    await assert_revert(
-        stark_plugin_signer_2.send_transaction(
-            [(stark_plugin_signer.account.contract_address, 'readOnPlugin', exec_arguments)]
-        ),
         reverted_with="SessionKey: only self"
     )

--- a/tests/test_session_key.py
+++ b/tests/test_session_key.py
@@ -294,7 +294,7 @@ async def test_executeOnPlugin(starknet: Starknet, contracts):
         account_address=account.contract_address
     )
 
-    revoke_session_key_arguments = [session.session_hash]
+    revoke_session_key_arguments = [session.session_public_key]
     exec_arguments = [
         session_plugin_signer.plugin_address,
         get_selector_from_name("revokeSessionKey"),

--- a/tests/test_session_key.py
+++ b/tests/test_session_key.py
@@ -1,18 +1,19 @@
 import pytest
 import asyncio
 import logging
-import copy
 from starkware.starknet.testing.starknet import Starknet
 from starkware.starknet.definitions.general_config import StarknetChainId
 from starkware.starknet.business_logic.state.state import BlockInfo
 from utils.utils import assert_revert, compile, cached_contract, assert_event_emitted, StarkKeyPair, build_contract, ERC165_INTERFACE_ID, ERC165_ACCOUNT_INTERFACE_ID
 from utils.plugin_signer import StarkPluginSigner
 from utils.session_keys_utils import build_session, SessionPluginSigner
+from starkware.starknet.compiler.compile import get_selector_from_name
 
 
 LOGGER = logging.getLogger(__name__)
 
 signer_key = StarkKeyPair(123456789987654321)
+signer_key_2 = StarkKeyPair(123456789987654322)
 session_key = StarkKeyPair(666666666666666666)
 wrong_session_key = StarkKeyPair(6767676767)
 
@@ -54,10 +55,12 @@ async def account_setup(starknet: Starknet):
     sts_plugin_decl = await starknet.declare(contract_class=sts_plugin_cls)
 
     account = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
+    account_2 = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
 
     await account.initialize(sts_plugin_decl.class_hash, [signer_key.public_key]).execute()
+    await account_2.initialize(sts_plugin_decl.class_hash, [signer_key_2.public_key]).execute()
 
-    return account, session_key_class.class_hash, sts_plugin_decl.class_hash
+    return account, account_2, session_key_class.class_hash, sts_plugin_decl.class_hash
 
 
 @pytest.fixture(scope='module')
@@ -71,11 +74,13 @@ async def dapp_setup(starknet: Starknet):
 
 @pytest.fixture
 def contracts(starknet: Starknet, account_setup, dapp_setup):
-    account, session_plugin_address, sts_plugin_address = account_setup
+    account, account_2, session_plugin_address, sts_plugin_address = account_setup
     dapp1, dapp2 = dapp_setup
     clean_state = starknet.state.copy()
 
     account = build_contract(account, state=clean_state)
+    account_2 = build_contract(account_2, state=clean_state)
+
     dapp1 = build_contract(dapp1, state=clean_state)
     dapp2 = build_contract(dapp2, state=clean_state)
 
@@ -85,18 +90,24 @@ def contracts(starknet: Starknet, account_setup, dapp_setup):
         plugin_address=sts_plugin_address
     )
 
+    stark_plugin_signer_2 = StarkPluginSigner(
+        stark_key=signer_key_2,
+        account=account_2,
+        plugin_address=sts_plugin_address
+    )
+
     session_plugin_signer = SessionPluginSigner(
         stark_key=session_key,
         account=account,
         plugin_address=session_plugin_address
     )
 
-    return account, stark_plugin_signer, session_plugin_signer, dapp1, dapp2, session_plugin_address
+    return account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_plugin_address
 
 
 @pytest.mark.asyncio
 async def test_call_dapp_with_session_key(starknet: Starknet, contracts):
-    account, stark_plugin_signer, session_plugin_signer, dapp1, dapp2, session_key_class = contracts
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_key_class = contracts
 
     # add session key plugin
     await stark_plugin_signer.add_plugin(session_key_class)
@@ -168,7 +179,7 @@ async def test_call_dapp_with_session_key(starknet: Starknet, contracts):
 
 @pytest.mark.asyncio
 async def test_supportsInterface(contracts):
-    account, stark_plugin_signer, session_plugin_signer, dapp1, dapp2, session_key_class = contracts
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_key_class = contracts
     await stark_plugin_signer.add_plugin(session_key_class)
     assert (await stark_plugin_signer.read_on_plugin("supportsInterface", [ERC165_INTERFACE_ID], plugin=session_key_class)).result[0] == [1]
     assert (await stark_plugin_signer.read_on_plugin("supportsInterface", [ERC165_ACCOUNT_INTERFACE_ID], plugin=session_key_class)).result[0] == [0]
@@ -177,7 +188,7 @@ async def test_supportsInterface(contracts):
 
 @pytest.mark.asyncio
 async def test_dapp_bad_signature(starknet: Starknet, contracts):
-    account, stark_plugin_signer, session_plugin_signer, dapp, dapp2, session_key_class = contracts
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp, dapp2, session_key_class = contracts
     assert (await dapp.get_balance().call()).result.res == 0
 
     await stark_plugin_signer.add_plugin(session_key_class)
@@ -206,7 +217,7 @@ async def test_dapp_bad_signature(starknet: Starknet, contracts):
 
 @pytest.mark.asyncio
 async def test_dapp_long_signature(starknet: Starknet, contracts):
-    account, stark_plugin_signer, session_plugin_signer, dapp, dapp2, session_key_class = contracts
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp, dapp2, session_key_class = contracts
     assert (await dapp.get_balance().call()).result.res == 0
 
     await stark_plugin_signer.add_plugin(session_key_class)
@@ -264,3 +275,42 @@ async def test_dapp_long_signature(starknet: Starknet, contracts):
     )
     # check it worked
     assert (await dapp.get_balance().call()).result.res == 47
+
+@pytest.mark.asyncio
+async def test_executeOnPlugin(starknet: Starknet, contracts):
+    # Account 2 tries to revoke a session key on Account 1, via executeOnPlugin and via readOnPlugin
+
+    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_key_class = contracts
+
+    await stark_plugin_signer.add_plugin(session_key_class)
+    update_starknet_block(starknet=starknet, block_timestamp=DEFAULT_TIMESTAMP)
+
+    session = build_session(
+        signer=stark_plugin_signer,
+        allowed_calls=[(dapp1.contract_address, 'set_balance')],
+        session_public_key=session_key.public_key,
+        session_expiration=DEFAULT_TIMESTAMP + 10,
+        chain_id=StarknetChainId.TESTNET.value,
+        account_address=account.contract_address
+    )
+
+    revoke_session_key_arguments = [session.session_hash]
+    exec_arguments = [
+        session_plugin_signer.plugin_address,
+        get_selector_from_name("revokeSessionKey"),
+        len(revoke_session_key_arguments),
+        *revoke_session_key_arguments
+    ]
+    await assert_revert(
+        stark_plugin_signer_2.send_transaction(
+            [(stark_plugin_signer.account.contract_address, 'executeOnPlugin', exec_arguments)]
+        ),
+        reverted_with="PluginAccount: only self"
+    )
+
+    await assert_revert(
+        stark_plugin_signer_2.send_transaction(
+            [(stark_plugin_signer.account.contract_address, 'readOnPlugin', exec_arguments)]
+        ),
+        reverted_with="SessionKey: only self"
+    )

--- a/tests/test_session_key.py
+++ b/tests/test_session_key.py
@@ -74,7 +74,7 @@ async def dapp_setup(starknet: Starknet):
 
 @pytest.fixture
 def contracts(starknet: Starknet, account_setup, dapp_setup):
-    account, account_2, session_plugin_address, sts_plugin_address = account_setup
+    account, account_2, session_plugin_class_hash, sts_plugin_class_hash = account_setup
     dapp1, dapp2 = dapp_setup
     clean_state = starknet.state.copy()
 
@@ -87,22 +87,22 @@ def contracts(starknet: Starknet, account_setup, dapp_setup):
     stark_plugin_signer = StarkPluginSigner(
         stark_key=signer_key,
         account=account,
-        plugin_address=sts_plugin_address
+        plugin_class_hash=sts_plugin_class_hash
     )
 
     stark_plugin_signer_2 = StarkPluginSigner(
         stark_key=signer_key_2,
         account=account_2,
-        plugin_address=sts_plugin_address
+        plugin_class_hash=sts_plugin_class_hash
     )
 
     session_plugin_signer = SessionPluginSigner(
         stark_key=session_key,
         account=account,
-        plugin_address=session_plugin_address
+        plugin_class_hash=session_plugin_class_hash
     )
 
-    return account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_plugin_address
+    return account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp1, dapp2, session_plugin_class_hash
 
 
 @pytest.mark.asyncio
@@ -296,7 +296,7 @@ async def test_executeOnPlugin(starknet: Starknet, contracts):
 
     revoke_session_key_arguments = [session.session_public_key]
     exec_arguments = [
-        session_plugin_signer.plugin_address,
+        session_plugin_signer.plugin_class_hash,
         get_selector_from_name("revokeSessionKey"),
         len(revoke_session_key_arguments),
         *revoke_session_key_arguments

--- a/tests/test_stark_signer.py
+++ b/tests/test_stark_signer.py
@@ -45,7 +45,7 @@ async def dapp(starknet: Starknet):
 
 @pytest.fixture
 def contracts(starknet: Starknet, account_setup, dapp):
-    account, sts_plugin_address = account_setup
+    account, sts_plugin_class_hash = account_setup
     clean_state = starknet.state.copy()
 
     account = build_contract(account, state=clean_state)
@@ -53,12 +53,12 @@ def contracts(starknet: Starknet, account_setup, dapp):
     stark_plugin_signer = StarkPluginSigner(
         stark_key=key_pair,
         account=account,
-        plugin_address=sts_plugin_address
+        plugin_class_hash=sts_plugin_class_hash
     )
 
     dapp = build_contract(dapp, state=clean_state)
 
-    return account, stark_plugin_signer, sts_plugin_address, dapp
+    return account, stark_plugin_signer, sts_plugin_class_hash, dapp
 
 
 @pytest.mark.asyncio

--- a/tests/test_stark_signer.py
+++ b/tests/test_stark_signer.py
@@ -1,8 +1,8 @@
 import pytest
 import asyncio
 from starkware.starknet.testing.starknet import Starknet
-from utils.utils import str_to_felt, cached_contract, compile
-from utils.utils import StarkKeyPair, ERC165_INTERFACE_ID, ERC165_ACCOUNT_INTERFACE_ID
+from utils.utils import str_to_felt, build_contract, compile
+from utils.utils import StarkKeyPair, ERC165_INTERFACE_ID, ERC165_ACCOUNT_INTERFACE_ID, assert_event_emitted, assert_revert
 from utils.plugin_signer import StarkPluginSigner
 
 key_pair = StarkKeyPair(1234)
@@ -13,18 +13,16 @@ new_key_pair = StarkKeyPair(5678)
 def event_loop():
     return asyncio.new_event_loop()
 
+
 @pytest.fixture(scope='module')
-def contract_classes():
+async def starknet():
+    return await Starknet.empty()
+
+
+@pytest.fixture(scope='module')
+async def account_setup(starknet: Starknet):
     account_cls = compile('contracts/account/PluginAccount.cairo')
     sts_plugin_cls = compile("contracts/plugins/signer/StarkSigner.cairo")
-    
-    return account_cls, sts_plugin_cls
-
-
-@pytest.fixture(scope='module')
-async def contract_init(contract_classes):
-    account_cls, sts_plugin_cls = contract_classes
-    starknet = await Starknet.empty()
 
     sts_plugin_decl = await starknet.declare(contract_class=sts_plugin_cls)
 
@@ -32,32 +30,40 @@ async def contract_init(contract_classes):
         contract_class=account_cls,
         constructor_calldata=[]
     )
-    
+
     await account.initialize(sts_plugin_decl.class_hash, [key_pair.public_key]).execute()
 
-    return starknet.state, account, sts_plugin_decl.class_hash
+    return account, sts_plugin_decl.class_hash
+
+
+@pytest.fixture(scope='module')
+async def dapp(starknet: Starknet):
+    dapp_cls = compile('contracts/test/Dapp.cairo')
+    await starknet.declare(contract_class=dapp_cls)
+    return await starknet.deploy(contract_class=dapp_cls, constructor_calldata=[])
 
 
 @pytest.fixture
-def contract_factory(contract_classes, contract_init):
-    account_cls, sts_plugin_cls = contract_classes
-    state, account, sts_plugin_hash = contract_init
-    _state = state.copy()
+def contracts(starknet: Starknet, account_setup, dapp):
+    account, sts_plugin_address = account_setup
+    clean_state = starknet.state.copy()
 
-    account = cached_contract(_state, account_cls, account)
+    account = build_contract(account, state=clean_state)
 
     stark_plugin_signer = StarkPluginSigner(
         stark_key=key_pair,
         account=account,
-        plugin_address=sts_plugin_hash
+        plugin_address=sts_plugin_address
     )
 
-    return account, stark_plugin_signer, sts_plugin_hash
+    dapp = build_contract(dapp, state=clean_state)
+
+    return account, stark_plugin_signer, sts_plugin_address, dapp
 
 
 @pytest.mark.asyncio
-async def test_initialise(contract_factory):
-    account, stark_plugin_signer, sts_plugin_hash = contract_factory
+async def test_initialise(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, _ = contracts
 
     execution_info = await account.getName().call()
     assert execution_info.result == (str_to_felt('PluginAccount'),)
@@ -70,8 +76,8 @@ async def test_initialise(contract_factory):
 
 
 @pytest.mark.asyncio
-async def test_change_public_key(contract_factory):
-    account, stark_plugin_signer, sts_plugin_hash = contract_factory
+async def test_change_public_key(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, _ = contracts
 
     await stark_plugin_signer.execute_on_plugin(
         selector_name="setPublicKey",
@@ -83,8 +89,55 @@ async def test_change_public_key(contract_factory):
 
 
 @pytest.mark.asyncio
-async def test_supportsInterface(contract_factory):
-    account, stark_plugin_signer, sts_plugin_hash = contract_factory
+async def test_supportsInterface(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, _ = contracts
     assert (await stark_plugin_signer.read_on_plugin("supportsInterface", [ERC165_INTERFACE_ID])).result[0] == [1]
     assert (await stark_plugin_signer.read_on_plugin("supportsInterface", [ERC165_ACCOUNT_INTERFACE_ID])).result[0] == [0]
     assert (await stark_plugin_signer.read_on_plugin("supportsInterface", [ERC165_ACCOUNT_INTERFACE_ID])).result[0] == [0]
+
+
+@pytest.mark.asyncio
+async def test_dapp(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, dapp = contracts
+    assert (await dapp.get_balance().call()).result.res == 0
+    tx_exec_info = await stark_plugin_signer.send_transaction(
+        calls=[(dapp.contract_address, 'set_balance', [47])],
+    )
+    assert_event_emitted(
+        tx_exec_info,
+        from_address=account.contract_address,
+        name='transaction_executed',
+        data=[]
+    )
+    assert (await dapp.get_balance().call()).result.res == 47
+
+
+@pytest.mark.asyncio
+async def test_dapp_bad_signature(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, dapp = contracts
+    assert (await dapp.get_balance().call()).result.res == 0
+
+    signed_tx = await stark_plugin_signer.get_signed_transaction(
+        calls=[(dapp.contract_address, 'set_balance', [47])],
+    )
+    signed_tx.signature[2] = 3333
+
+    await assert_revert(
+        stark_plugin_signer.send_signed_tx(signed_tx)
+    )
+    assert (await dapp.get_balance().call()).result.res == 0
+
+
+@pytest.mark.asyncio
+async def test_dapp_long_signature(contracts):
+    account, stark_plugin_signer, sts_plugin_hash, dapp = contracts
+    assert (await dapp.get_balance().call()).result.res == 0
+
+    signed_tx = await stark_plugin_signer.get_signed_transaction(
+        calls=[(dapp.contract_address, 'set_balance', [47])],
+    )
+    signed_tx.signature.extend([1, 1, 1, 1])
+    await assert_revert(
+        stark_plugin_signer.send_signed_tx(signed_tx)
+    )
+    assert (await dapp.get_balance().call()).result.res == 0

--- a/tests/utils/plugin_signer.py
+++ b/tests/utils/plugin_signer.py
@@ -12,9 +12,9 @@ TRANSACTION_VERSION = 1
 
 
 class PluginSigner:
-    def __init__(self, account: StarknetContract, plugin_address):
+    def __init__(self, account: StarknetContract, plugin_class_hash):
         self.account = account
-        self.plugin_address = plugin_address
+        self.plugin_class_hash = plugin_class_hash
 
     @abstractmethod
     def sign(self, message_hash: int) -> List[int]:
@@ -69,7 +69,7 @@ class PluginSigner:
             arguments = []
 
         if plugin is None:
-            plugin = self.plugin_address
+            plugin = self.plugin_class_hash
 
         exec_arguments = [
             plugin,
@@ -84,7 +84,7 @@ class PluginSigner:
             arguments = []
 
         if plugin is None:
-            plugin = self.plugin_address
+            plugin = self.plugin_class_hash
 
         selector = get_selector_from_name(selector_name)
         return await self.account.executeOnPlugin(plugin, selector, arguments).call()
@@ -102,10 +102,10 @@ class PluginSigner:
 
 
 class StarkPluginSigner(PluginSigner):
-    def __init__(self, stark_key: StarkKeyPair, account: StarknetContract, plugin_address):
-        super().__init__(account, plugin_address)
+    def __init__(self, stark_key: StarkKeyPair, account: StarknetContract, plugin_class_hash):
+        super().__init__(account, plugin_class_hash)
         self.stark_key = stark_key
         self.public_key = stark_key.public_key
 
     def sign(self, message_hash: int) -> List[int]:
-        return [self.plugin_address] + list(self.stark_key.sign(message_hash))
+        return [self.plugin_class_hash] + list(self.stark_key.sign(message_hash))

--- a/tests/utils/plugin_signer.py
+++ b/tests/utils/plugin_signer.py
@@ -87,7 +87,7 @@ class PluginSigner:
             plugin = self.plugin_address
 
         selector = get_selector_from_name(selector_name)
-        return await self.account.readOnPlugin(plugin, selector, arguments).call()
+        return await self.account.executeOnPlugin(plugin, selector, arguments).call()
 
     async def add_plugin(self, plugin: int, plugin_arguments=None):
         if plugin_arguments is None:

--- a/tests/utils/session_keys_utils.py
+++ b/tests/utils/session_keys_utils.py
@@ -74,8 +74,8 @@ def build_session(signer, allowed_calls: List[AllowedCall], session_public_key: 
 
 
 class SessionPluginSigner(PluginSigner):
-    def __init__(self, stark_key: StarkKeyPair, account: StarknetContract, plugin_address):
-        super().__init__(account, plugin_address)
+    def __init__(self, stark_key: StarkKeyPair, account: StarknetContract, plugin_class_hash):
+        super().__init__(account, plugin_class_hash)
         self.stark_key = stark_key
         self.public_key = stark_key.public_key
 
@@ -113,7 +113,7 @@ class SessionPluginSigner(PluginSigner):
         session_signature = self.stark_key.sign(transaction_hash)
         proofs_flat = [item for proof in proofs for item in proof]
         signature = [
-            self.plugin_address,
+            self.plugin_class_hash,
             *session_signature,          # session signature
             session.session_public_key,  # session_key
             session.session_expiration,  # expiration


### PR DESCRIPTION
There was no length validation of the signatures any of the plugins.
This was a security concern, since an attacker can modify the signature and add more data to make the Account spend more ETH on fees.

This illustrates the problem with passing data in the signature, it makes harder to write plugin data itself is not signed

This also includes the changes in https://github.com/argentlabs/starknet-plugin-account/pull/13