### PR TITLE
Removed event on account creation

### DIFF
--- a/contracts/account/library.cairo
+++ b/contracts/account/library.cairo
@@ -91,9 +91,6 @@ namespace PluginAccount {
 
         initialize_plugin(plugin, plugin_calldata_len, plugin_calldata);
 
-        let (self) = get_contract_address();
-        account_created.emit(self);
-
         return ();
     }
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -30,14 +30,24 @@ async def starknet():
 async def account_setup(starknet: Starknet):
     account_cls = compile('contracts/account/PluginAccount.cairo')
     sts_plugin_cls = compile("contracts/plugins/signer/StarkSigner.cairo")
+    proxy_cls = compile("contracts/upgrade/Proxy.cairo")
     sts_plugin_decl = await starknet.declare(contract_class=sts_plugin_cls)
+    account_cls_decl = await starknet.declare(contract_class=account_cls)
 
     account = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
     await account.initialize(sts_plugin_decl.class_hash, [signer_key.public_key]).execute()
 
-    account2 = await starknet.deploy(contract_class=account_cls, constructor_calldata=[])
-    await account2.initialize(sts_plugin_decl.class_hash, [signer_key_2.public_key]).execute()
-    return account, account2, account_cls, sts_plugin_decl
+    account2 = await starknet.deploy(contract_class=proxy_cls, 
+        constructor_calldata=[
+            account_cls_decl.class_hash,
+            get_selector_from_name('initialize'),
+            3, # all calldata length 
+            sts_plugin_decl.class_hash,
+            1, # plugin call data length
+            signer_key_2.public_key]
+    )
+
+    return account, account2, account_cls, sts_plugin_decl, proxy_cls
 
 
 @pytest.fixture(scope='module')
@@ -56,12 +66,12 @@ async def dapp_setup(starknet: Starknet):
 
 @pytest.fixture
 async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_setup):
-    account, account_2, account_cls, sts_plugin_decl = account_setup
+    account, account_2, account_cls, sts_plugin_decl, proxy_cls = account_setup
     session_key_decl = session_plugin_setup
 
     clean_state = starknet.state.copy()
     account = build_contract(account, state=clean_state)
-    account_2 = build_contract(account_2, state=clean_state)
+    account_2 = build_contract(account_2, state=clean_state, custom_abi=account_cls.abi)
 
     stark_plugin_signer = StarkPluginSigner(
         stark_key=signer_key,
@@ -82,21 +92,25 @@ async def network(starknet: Starknet, account_setup, session_plugin_setup, dapp_
     )
     dapp = build_contract(dapp_setup, state=clean_state)
 
-    return account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp
+    return account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp
 
 
 @pytest.mark.asyncio
 async def test_addPlugin(network):
-    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
+    account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     plugin_class_hash = session_plugin_signer.plugin_class_hash
     assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
     await stark_plugin_signer.add_plugin(plugin_class_hash)
-    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 1
+    assert (await account.isPlugin(plugin_class_hash).call()).result.success == 1 
+    
+    assert (await account_2.isPlugin(plugin_class_hash).call()).result.success == 0
+    await stark_plugin_signer_2.add_plugin(plugin_class_hash)
+    assert (await account_2.isPlugin(plugin_class_hash).call()).result.success == 1
 
 
 @pytest.mark.asyncio
 async def test_removePlugin(network):
-    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
+    account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     plugin_class_hash = session_plugin_signer.plugin_class_hash
     assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
     await stark_plugin_signer.add_plugin(plugin_class_hash)
@@ -104,10 +118,16 @@ async def test_removePlugin(network):
     await stark_plugin_signer.remove_plugin(plugin_class_hash)
     assert (await account.isPlugin(plugin_class_hash).call()).result.success == 0
 
+    assert (await account_2.isPlugin(plugin_class_hash).call()).result.success == 0
+    await stark_plugin_signer_2.add_plugin(plugin_class_hash)
+    assert (await account_2.isPlugin(plugin_class_hash).call()).result.success == 1
+    await stark_plugin_signer_2.remove_plugin(plugin_class_hash)
+    assert (await account_2.isPlugin(plugin_class_hash).call()).result.success == 0
+
 
 @pytest.mark.asyncio
 async def test_supportsInterface(network):
-    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
+    account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     assert (await account.supportsInterface(ERC165_INTERFACE_ID).call()).result.success == 1
     assert (await account.supportsInterface(ERC165_ACCOUNT_INTERFACE_ID).call()).result.success == 1
     assert (await account.supportsInterface(0x123).call()).result.success == 0
@@ -116,7 +136,7 @@ async def test_supportsInterface(network):
 
 @pytest.mark.asyncio
 async def test_dapp(network):
-    account, stark_plugin_signer, stark_plugin_signer, session_plugin_signer, dapp = network
+    account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     assert (await dapp.get_balance().call()).result.res == 0
     tx_exec_info = await stark_plugin_signer.send_transaction(
         calls=[(dapp.contract_address, 'set_balance', [47])],
@@ -134,7 +154,7 @@ async def test_dapp(network):
 async def test_executeOnPlugin(network):
     # Account 2 tries to change the signer key on Account 1, via executeOnPlugin and via readOnPlugin
 
-    account, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
+    account, account_2, stark_plugin_signer, stark_plugin_signer_2, session_plugin_signer, dapp = network
     read_execution_info = await stark_plugin_signer.read_on_plugin("getPublicKey")
     assert read_execution_info.result[0] == [signer_key.public_key]
 


### PR DESCRIPTION
During account creation on Goerli testnet I have an error during the deployment because of this  [line in initializer](https://github.com/argentlabs/starknet-plugin-account/blob/main/contracts/account/library.cairo#L94)
This error is not caught with the test in python. 

I past below the error I have. This error is thrown deploying through both UDC and deployAccount
```
GatewayError: Error at pc=0:89:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:336)
Unknown location (pc=0:312)

Error in the called contract (0x7052d555b167b3a6f2e8a17d86939a7a8263368178a7b3db7922a2239a5e62e):
Error at pc=0:50:
Got an exception while executing a hint.
Cairo traceback (most recent call last):
Unknown location (pc=0:1276)
Unknown location (pc=0:1256)
Unknown location (pc=0:519)
Unknown location (pc=0:463)
Unknown location (pc=0:440)

Traceback (most recent call last):
  File "<hint7>", line 3, in <module>
AssertionError: normalize_address() cannot be used with the current constants.
    at SequencerProvider.fetchEndpoint (file:///Users/thomas.brillard/Documents/Starknet/deployer/node_modules/starknet/dist/index.mjs:3185:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Account.estimateAccountDeployFee (file:///Users/thomas.brillard/Documents/Starknet/deployer/node_modules/starknet/dist/index.mjs:4403:22)
    at async Account.getSuggestedMaxFee (file:///Users/thomas.brillard/Documents/Starknet/deployer/node_modules/starknet/dist/index.mjs:4602:23)
    at async Account.deployAccount (file:///Users/thomas.brillard/Documents/Starknet/deployer/node_modules/starknet/dist/index.mjs:4541:49)
    at async file:///Users/thomas.brillard/Documents/Starknet/deployer/deploy.js:87:48 {
  errorCode: 'StarknetErrorCode.TRANSACTION_FAILED'
}
```
